### PR TITLE
Fix the compile warning & build steps, and add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# autotools generated
+.deps/
+Makefile
+Makefile.in
+aclocal.m4
+autom4te.cache/
+compile
+config.h
+config.h.in
+config.log
+config.status
+configure
+depcomp
+install-sh
+missing
+stamp-h1
+
+# compiling output
+*.o
+xclip
+
+# temporary files
+*.swp

--- a/INSTALL
+++ b/INSTALL
@@ -6,6 +6,7 @@ BUILDING
 You should be able to build and install xclip by running the following commands
 in the xclip source directory:
 
+autoreconf		# create configuration files
 ./configure		# create the Makefile
 make			# build the binary
 su			# su to root to install

--- a/xclip.c
+++ b/xclip.c
@@ -299,7 +299,10 @@ doIn(Window win, const char *progname)
     }
 
     /* Avoid making the current directory in use, in case it will need to be umounted */
-    chdir("/");
+    if (chdir("/") == -1) {
+	errperror(3, progname, ": ", "chdir to \"/\"");
+	return EXIT_FAILURE;
+    }
 
     /* loop and wait for the expected number of
      * SelectionRequest events


### PR DESCRIPTION
Thanks for the work on xclip. It is really great and useful.

I built xclip from the source and found some problems.
I send this pull-request to fix them for contributing to this project.

1). A compile warning:
xclip.c: In function 'doIn':
xclip.c:302:5: warning: ignoring return value of 'chdir', declared with attribute warn_unused_result [-Wunused-result]
     chdir("/");

2). Build steps in INSTALL
"autoconf" is missing

3). No .gitignore