### PR TITLE
Add the remove-last-newline option

### DIFF
--- a/xclip.1
+++ b/xclip.1
@@ -35,6 +35,9 @@ print the selection to standard out (generally for piping to a file or program)
 \fB\-f\fR, \fB\-filter\fR
 when xclip is invoked in the in mode with output level set to silent (the defaults), the filter option will cause xclip to print the text piped to standard in back to standard out unmodified
 .TP
+\fB\-r\fR, \fB\-rmlastnl\fR
+when the last character of the selection is a newline character, remove it. Newline characters that are not the last character in the selection are not affected. If the selection does not end with a newline character, this option has no effect. This option is useful for copying one-line output of programs like \fBpwd\fR to the clipboard to paste it again into the command prompt without executing the line immideately due to the newline character \fBpwd\fR appends.
+.TP
 \fB\-l\fR, \fB\-loops\fR
 number of X selection requests (pastes into X applications) to wait for before exiting, with a value of 0 (default) causing xclip to wait for an unlimited number of requests until another application (possibly another invocation of xclip) takes ownership of the selection
 .TP

--- a/xclip.c
+++ b/xclip.c
@@ -35,7 +35,7 @@
 #include "xclib.h"
 
 /* command line option table for XrmParseCommand() */
-XrmOptionDescRec opt_tab[13];
+XrmOptionDescRec opt_tab[14];
 
 /* Options that get set on the command line */
 int sloop = 0;			/* number of loops */
@@ -47,6 +47,7 @@ Atom target = XA_STRING;
 static int fverb = OSILENT;	/* output level */
 static int fdiri = T;		/* direction is in */
 static int ffilt = F;		/* filter mode */
+static int frmnl = F;		/* remove (single) newline character at the very end if present */
 
 Display *dpy;			/* connection to X11 display */
 XrmDatabase opt_db = NULL;	/* database for options */
@@ -98,6 +99,12 @@ doOptMain(int argc, char *argv[])
 	/* filter mode only allowed in silent mode */
 	if (fverb == OSILENT)
 	    ffilt = T;
+    }
+
+    /* set "remove last newline character if present" mode */
+    if (XrmGetResource(opt_db, "xclip.rmlastnl", "Xclip.RmLastNl", &rec_typ, &rec_val)
+	) {
+	frmnl = T;
     }
 
     /* check for -help and -version */
@@ -252,6 +259,11 @@ doIn(Window win, const char *progname)
 	    sel_len += fread(sel_buf + sel_len, sizeof(char), sel_all - sel_len, fil_handle);
 	}
     } while (fil_current < fil_number);
+
+    /* remove the last newline character if necessary */
+    if (frmnl && sel_len && sel_buf[sel_len - 1] == '\n') {
+	sel_len--;
+    }
 
     /* if there are no files being read from (i.e., input
      * is from stdin not files, and we are in filter mode,
@@ -462,6 +474,11 @@ doOut(Window win)
 	}
     }
 
+    /* remove the last newline character if necessary */
+    if (frmnl && sel_len && sel_buf[sel_len - 1] == '\n') {
+	sel_len--;
+    }
+
     if (sel_len) {
 	/* only print the buffer out, and free it, if it's not
 	 * empty
@@ -487,7 +504,7 @@ main(int argc, char *argv[])
      * do it while sticking to pure ANSI C. The option and specifier
      * members have a type of volatile char *, so they need to be allocated
      * by strdup or malloc, you can't set them to a string constant at
-     * declare time, this is note pure ANSI C apparently, although it does
+     * declare time, this is not pure ANSI C apparently, although it does
      * work with gcc
      */
 
@@ -568,6 +585,12 @@ main(int argc, char *argv[])
     opt_tab[12].specifier = xcstrdup(".target");
     opt_tab[12].argKind = XrmoptionSepArg;
     opt_tab[12].value = (XPointer) NULL;
+
+    /* "remove newline if it is the last character" entry */
+    opt_tab[13].option = xcstrdup("-rmlastnl");
+    opt_tab[13].specifier = xcstrdup(".rmlastnl");
+    opt_tab[13].argKind = XrmoptionNoArg;
+    opt_tab[13].value = (XPointer) xcstrdup(ST);
 
     /* parse command line options */
     doOptMain(argc, argv);

--- a/xcprint.c
+++ b/xcprint.c
@@ -48,6 +48,7 @@ prhelp(char *name)
 	    "\"secondary\", \"clipboard\" or \"buffer-cut\")\n"
 	    "      -noutf8      don't treat text as utf-8, use old unicode\n"
 	    "      -target      use the given target atom\n"
+	    "      -rmlastnl    remove the last newline charater if present\n"
 	    "      -version     version information\n"
 	    "      -silent      errors only, run in background (default)\n"
 	    "      -quiet       run in foreground, show what's happening\n"


### PR DESCRIPTION
This is an option proposed by Philipp Spitzer.
See https://github.com/astrand/xclip/issues/7

Use his patch (but only keep code related to the rmlastnl option).
An new option "-rmlastnl" is added to remove the last newline character if present.

Fix the issue #7.