### PR TITLE
Add "-f -" flags to tar

### DIFF
--- a/xclip-pastefile
+++ b/xclip-pastefile
@@ -4,4 +4,4 @@ if [ "x$1" != "x" ]; then
     echo "Usage: $0" >&2
     exit 1
 fi
-xclip -selection secondary -o | gunzip -c | tar xv
+xclip -selection secondary -o | gunzip -c | tar xvf -


### PR DESCRIPTION
BSD implementations of tar use tape device as default file, so "tar xv" would
extract files from tape device instead of standard input.