### PR TITLE
Special case for xclip to support --help

### DIFF
--- a/xclip.c
+++ b/xclip.c
@@ -69,6 +69,13 @@ doOptMain(int argc, char *argv[])
 {
     /* Initialise resource manager and parse options into database */
     XrmInitialize();
+
+    if (!strcmp(argv[1], "--help"))
+    {
+	prhelp(argv[0]);
+	exit(0);
+    }
+
     XrmParseCommand(&opt_db, opt_tab, sizeof(opt_tab) / sizeof(opt_tab[0]), PACKAGE_NAME, &argc,
 		    argv);
 


### PR DESCRIPTION
When somebody tries a new tool they're likely to try --help to find how to use it.

This commit adds a special case to show the usage information when called with --help as the first argument.