### PR TITLE
Avoid printf "%s" NULL

### DIFF
--- a/xcprint.c
+++ b/xcprint.c
@@ -86,7 +86,7 @@ errxdisplay(char *display)
     if (display == NULL)
 	display = getenv("DISPLAY");
 
-    fprintf(stderr, "Error: Can't open display: %s\n", display);
+    fprintf(stderr, "Error: Can't open display: %s\n", display ? display : "(null)");
     exit(EXIT_FAILURE);
 }
 


### PR DESCRIPTION
If the DISPLAY environment variable is unset, the error message tries to
print a NULL pointer with %s. Avoid this by checking display for NULL.