### PR TITLE
Prepend rm arguments with -- in xclip-cutfile

### DIFF
--- a/xclip-cutfile
+++ b/xclip-cutfile
@@ -12,4 +12,4 @@ xclip-copyfile "$@"
 if [ "x$1" = "x-p" ]; then
     shift
 fi
-rm "$@"
+rm -- "$@"


### PR DESCRIPTION
It makes `xclip-cutfile` more robust since the final `rm` will not treat any of its arguments as flags. All the arguments passed to `rm` are going to be treated as file names.