### PR TITLE
Revise the error message

### DIFF
--- a/xclip.c
+++ b/xclip.c
@@ -464,10 +464,7 @@ doOut(Window win)
 		}
 		else {
 		    /* no fallback available, exit with failure */
-		    char *atom_name = XGetAtomName(dpy, target);
-		    fprintf(stderr, "Error: target %s not available\n", atom_name);
-		    XFree(atom_name);
-		    return EXIT_FAILURE;
+		    errconvsel(dpy, target, sseln);
 		}
 	    }
 

--- a/xcprint.c
+++ b/xcprint.c
@@ -72,7 +72,7 @@ prversion(void)
 void
 errmalloc(void)
 {
-    fprintf(stderr, "Error: Could not allocate memory.\n");
+    fprintf(stderr, "xclip: Error: Could not allocate memory.\n");
     exit(EXIT_FAILURE);
 }
 
@@ -86,7 +86,7 @@ errxdisplay(char *display)
     if (display == NULL)
 	display = getenv("DISPLAY");
 
-    fprintf(stderr, "Error: Can't open display: %s\n", display ? display : "(null)");
+    fprintf(stderr, "xclip: Error: Can't open display: %s\n", display ? display : "(null)");
     exit(EXIT_FAILURE);
 }
 
@@ -128,4 +128,18 @@ errperror(int prf_tot, ...)
 
     /* free the complete string */
     free(msg_all);
+}
+
+/* failure to convert selection */
+void
+errconvsel(Display *display, Atom target, Atom selection)
+{
+    char *atom_name = XGetAtomName(display, target);
+
+    fprintf(stderr, "xclip: Error: Cannot performance ConvertSelection to target %s\n", atom_name);
+    fprintf(stderr, "xclip: Error: Onwer of selection: 0x%lx\n", XGetSelectionOwner(display, selection));
+
+    XFree(atom_name);
+
+    exit(EXIT_FAILURE);
 }

--- a/xcprint.h
+++ b/xcprint.h
@@ -24,3 +24,4 @@ extern void prversion(void);
 extern void errmalloc(void);
 extern void errxdisplay(char *);
 extern void errperror(int, ...);
+extern void errconvsel(Display *display, Atom target, Atom selection);


### PR DESCRIPTION
Fix the issue #38 (https://github.com/astrand/xclip/issues/38).

Add a prefix "xclip::Error" with the error message so that the user can know what program is causing the error.
Print the id of the owner of the selection in the verbose mode so that the developer can know what program cannot fulfill the request of ConvertSelection.