### PR TITLE
Fix -loops failure with large-data-transfers

### DIFF
--- a/xclip.c
+++ b/xclip.c
@@ -424,9 +424,6 @@ doIn(Window win, const char *progname)
 
 	    if (finished) {
 	    del_requestor(requestor);
-	    }
-
-	    if (!requestors) {
 	    break;
 	    }
 	}


### PR DESCRIPTION
The -loops option is broken after merging the pull-request #57 (https://github.com/astrand/xclip/pull/57).

Here is a sample transcript to reproduce the problem.
hwangcc23-BU401LG:~$ dd 'if=/dev/zero' 'bs=2000' 'count=1000' | tr '\000' 'a' | xclip -i -quiet -l 1

Expect: xclip should exist right after any requestor (ex: `xclip -o`) retrieved data.
What I saw: xclip didn't exist.

Break out the while(1) loop once there is one SelectionRequest completed such that dloop can be decreased by one and compared to sleep for fixing the problem.