### PR TITLE
Initial commit of Bash tab completion code.

### DIFF
--- a/xclip.bash-completion
+++ b/xclip.bash-completion
@@ -1,0 +1,59 @@
+# -*- shell-script -*-
+# bash completion for xclip, xclip-{copy,cut,paste}file.
+# This file is part of the xclip program.
+# This lists available TARGETS for -t, available selections for -se,
+# available options for -, and files otherwise.
+
+_getselection() {
+    # Did the user specify which selection to use already?
+    # Look through words for "-selection" then return next word.
+    # (This affects which TARGETS are returned.)
+    local w nextandbreak
+
+    for w in "${COMP_WORDS[@]}"; do
+	[[ -z "$nextandbreak" ]] || break
+	[[ $w == -se* ]] && nextandbreak=1
+    done	
+
+    if [[ "$w" && $w != -se* ]]; then
+	echo "$w"
+    else
+	echo "Primary"
+    fi
+}
+
+_xclip()
+{
+    local cur prev selection options
+
+    COMPREPLY=()
+    cur=${COMP_WORDS[COMP_CWORD]}
+
+	prev=${COMP_WORDS[COMP_CWORD-1]}
+	case $prev in
+	    -t*)
+		selection=$( _getselection )
+		options=$( xclip -selection $selection -target TARGETS 2>/dev/null )
+		COMPREPLY=( $( compgen -W "$options" -- $cur ) )
+		return 0
+		;;
+	    -se*)
+		options="Primary Secondary Clipboard Buffer-cut"
+		COMPREPLY=( $( compgen -W "$options" -- ${cur^} ) )
+		return 0
+		;;
+	esac
+
+	# Begins with -, so command line option (or badly named file, I suppose)
+	if [[ "$cur" == -* ]]; then
+	    options="-in -out -loops -display -help -selection"
+	    options+=" -c -noutf8 -target -T -rmlastnl -version"
+	    options+=" -silent -quiet -verbose"
+	    COMPREPLY=(  $( compgen -W "$options" -- $cur ) )
+	    return 0
+	fi
+
+	# Fall back to files
+	COMPREPLY=(  $( compgen -f -- $cur ) )
+}
+complete -F _xclip xclip


### PR DESCRIPTION
Working for all basic cases. Tab completion of filenames, all flags,
all selections (case insensitive), and most TARGETS. ("Most" because
this code cannot yet handle spaces in the property names.)

For example, below I typed "**xclip -se** *TAB* **s** *TAB* **-t** *TAB* *TAB* *TAB*"

```
$ xclip -selection Secondary -target 
COMPOUND_TEXT             TARGETS                   text/plain;charset=utf-8
MULTIPLE                  TEXT                      TIMESTAMP
STRING                    text/plain                UTF8_STRING
```

As you can see it looked up the targets available for the selection I mentioned and offers them up for completion.

Note: as a debian package, this file is supposed to install using `dh_bash-completion`, but I'm not exactly sure where to put that. Alternately, this could be copied by hand to /etc/bash_completion.d/ or even simply sourced at login.