### PR TITLE
Check for zombie

### DIFF
--- a/xctest
+++ b/xctest
@@ -44,7 +44,7 @@ echo goodbye | ./xclip -i
 sleep 1
 if ps $! >/dev/null; then 
     echo "FAIL: Zombie xclip yet lives! Killing."
-    pkill xclip
+    killall xclip
     exit 1
 else
     echo "PASS: xclip exited correctly after losing selection."

--- a/xctest
+++ b/xctest
@@ -36,6 +36,20 @@ do
 	esac
 done
 
+# Check is xclip is quitting properly.
+echo "Testing whether xclip exits correctly when the selection is lost."
+echo hello | ./xclip -q -i 2>/dev/null &
+sleep 1
+echo goodbye | ./xclip -i
+sleep 1
+if ps $! >/dev/null; then 
+    echo "FAIL: Zombie xclip yet lives! Killing."
+    pkill xclip
+    exit 1
+else
+    echo "PASS: xclip exited correctly after losing selection."
+fi
+
 # test xclip on different amounts of data to bring out any errors
 for lines in 2 16 128 1024 8192
 do


### PR DESCRIPTION
This patch adds to `xctest` a test to make sure xclip dies as it should when it no longer holds the selection. Note that the current xclip code is buggy and fails this test (bug #64)