### PR TITLE
Added -secure mode to wipe selection buffers and paste once

### DIFF
--- a/xclib.c
+++ b/xclib.c
@@ -328,7 +328,7 @@ xcin(Display * dpy,
      Window * win,
      XEvent evt,
      Atom * pty, Atom target, unsigned char *txt, unsigned long len, unsigned long *pos,
-     unsigned int *context, long *chunk_size, int *dloop)
+     unsigned int *context, long *chunk_size)
 {
     unsigned long chunk_len;	/* length of current chunk (for incr
 				 * transfers only)
@@ -396,7 +396,6 @@ xcin(Display * dpy,
 	    XChangeProperty(dpy,
 			    *win,
 			    *pty, target, 8, PropModeReplace, (unsigned char *) txt, (int) len);
-        *dloop += 1;
 	}
 
 	/* Perhaps FIXME: According to ICCCM section 2.5, we should
@@ -472,7 +471,6 @@ xcin(Display * dpy,
 	     * finished the transfer
 	     */
 	    XChangeProperty(dpy, *win, *pty, target, 8, PropModeReplace, 0, 0);
-        *dloop += 1;
 	}
 	XFlush(dpy);
 

--- a/xclib.c
+++ b/xclib.c
@@ -328,7 +328,7 @@ xcin(Display * dpy,
      Window * win,
      XEvent evt,
      Atom * pty, Atom target, unsigned char *txt, unsigned long len, unsigned long *pos,
-     unsigned int *context, long *chunk_size)
+     unsigned int *context, long *chunk_size, int *dloop)
 {
     unsigned long chunk_len;	/* length of current chunk (for incr
 				 * transfers only)
@@ -396,6 +396,7 @@ xcin(Display * dpy,
 	    XChangeProperty(dpy,
 			    *win,
 			    *pty, target, 8, PropModeReplace, (unsigned char *) txt, (int) len);
+        *dloop += 1;
 	}
 
 	/* Perhaps FIXME: According to ICCCM section 2.5, we should
@@ -471,6 +472,7 @@ xcin(Display * dpy,
 	     * finished the transfer
 	     */
 	    XChangeProperty(dpy, *win, *pty, target, 8, PropModeReplace, 0, 0);
+        *dloop += 1;
 	}
 	XFlush(dpy);
 

--- a/xclib.c
+++ b/xclib.c
@@ -28,6 +28,13 @@
 #include "xcprint.h"
 #include "xclib.h"
 
+/* a memset function that won't be optimized away by compler */
+void 
+xcmemzero(void *ptr, size_t len)
+{
+    memset_func(ptr, 0, len);
+}
+
 /* check a pointer to allocated memory, print an error if it's null */
 void
 xcmemcheck(void *ptr)

--- a/xclib.h
+++ b/xclib.h
@@ -60,3 +60,7 @@ extern void *xcmalloc(size_t);
 extern void *xcrealloc(void*, size_t);
 extern void *xcstrdup(const char *);
 extern void xcmemcheck(void*);
+
+/* volatile prevents compiler from causing dead-store elimination with optimization enabled */
+typedef void *(*memset_t)(void *, int, size_t);
+static volatile memset_t memset_func = memset;

--- a/xclib.h
+++ b/xclib.h
@@ -64,3 +64,4 @@ extern void xcmemcheck(void*);
 /* volatile prevents compiler from causing dead-store elimination with optimization enabled */
 typedef void *(*memset_t)(void *, int, size_t);
 static volatile memset_t memset_func = memset;
+void xcmemzero(void *ptr, size_t len);

--- a/xclib.h
+++ b/xclib.h
@@ -54,8 +54,7 @@ extern int xcin(
 	unsigned long,
 	unsigned long*,
 	unsigned int*,
-	long*,
-    int*
+	long*
 );
 extern void *xcmalloc(size_t);
 extern void *xcrealloc(void*, size_t);

--- a/xclib.h
+++ b/xclib.h
@@ -54,7 +54,8 @@ extern int xcin(
 	unsigned long,
 	unsigned long*,
 	unsigned int*,
-	long*
+	long*,
+    int*
 );
 extern void *xcmalloc(size_t);
 extern void *xcrealloc(void*, size_t);

--- a/xclip.1
+++ b/xclip.1
@@ -70,8 +70,10 @@ operate in legacy (i.e. non UTF-8) mode for backwards compatibility
 (Use this option only when really necessary, as the old behavior was broken)
 .TP
 \fB\-secure\fR
-zero selection buffer if if it contains sensitive informaiton and imply -loops 1 to clear selection after one paste (-loops will override)
-(Use this option only when really necessary, as the old behavior was broken)
+zero selection buffer if if it contains sensitive informaiton and imply -wait 1 (-wait will override if set)
+.TP
+\fB\-wait\fR
+number of milliseconds to wait after the first paste event before exiting
 
 .PP
 xclip reads text from standard in or files and makes it available to other X applications for pasting as an X selection (traditionally with the middle mouse button). It reads from all files specified, or from standard in if no files are specified. xclip can also print the contents of a selection to standard out with the

--- a/xclip.1
+++ b/xclip.1
@@ -68,6 +68,10 @@ provide a running commentary of what xclip is doing
 \fB\-noutf8\fR
 operate in legacy (i.e. non UTF-8) mode for backwards compatibility
 (Use this option only when really necessary, as the old behavior was broken)
+.TP
+\fB\-secure\fR
+zero selection buffer if if it contains sensitive informaiton and imply -loops 1 to clear selection after one paste (-loops will override)
+(Use this option only when really necessary, as the old behavior was broken)
 
 .PP
 xclip reads text from standard in or files and makes it available to other X applications for pasting as an X selection (traditionally with the middle mouse button). It reads from all files specified, or from standard in if no files are specified. xclip can also print the contents of a selection to standard out with the

--- a/xclip.c
+++ b/xclip.c
@@ -468,7 +468,7 @@ start:
 	       See ICCCM section 2.2.
 	       Set dloop to sloop for forcing exit after all transfers are completed. */
 	    dloop = sloop;
-        /* if there is no more in-progress transfer, force exit */
+            /* if there is no more in-progress transfer, force exit */
 	    if (!requestors) {
 	        return EXIT_SUCCESS;
 	    }

--- a/xclip.c
+++ b/xclip.c
@@ -373,8 +373,9 @@ doIn(Window win, const char *progname)
 	pid = fork();
 	/* exit the parent process; */
 	if (pid) {
-        if (fsecm)
+        if (fsecm) {
             xcmemzero(sel_buf,sel_len);
+        }
 	    exit(EXIT_SUCCESS);
         }
     }
@@ -582,13 +583,15 @@ doOut(Window win)
 	 */
 	printSelBuf(stdout, sel_type, sel_buf, sel_len);
 	if (sseln == XA_STRING) {
-        if (fsecm)
+        if (fsecm) {
             xcmemzero(sel_buf,sel_len);
+        }
 	    XFree(sel_buf);
 	}
 	else {
-        if (fsecm)
+        if (fsecm) {
             xcmemzero(sel_buf,sel_len);
+        }
 	    free(sel_buf);
 	}
     }

--- a/xclip.c
+++ b/xclip.c
@@ -477,13 +477,14 @@ start:
 	    continue;
 	    }
 
-	    finished = xcin(dpy, &(requestor->cwin), evt, &(requestor->pty), target, sel_buf, sel_len, &(requestor->sel_pos), &(requestor->context), &(requestor->chunk_size), &dloop);
+	    finished = xcin(dpy, &(requestor->cwin), evt, &(requestor->pty), target, sel_buf, sel_len, &(requestor->sel_pos), &(requestor->context), &(requestor->chunk_size));
 
 	    if (finished) {
 	    del_requestor(requestor);
 	    break;
 	    }
-	}
+        }
+    dloop++;		/* increment loop counter */
     }
     
     if (fsecm)

--- a/xclip.c
+++ b/xclip.c
@@ -291,7 +291,8 @@ doIn(Window win, const char *progname)
     unsigned long sel_len = 0;	/* length of sel_buf */
     unsigned long sel_all = 0;	/* allocated size of sel_buf */
     XEvent evt;			/* X Event Structures */
-    int dloop = 0;		/* done loops counter */
+    int dloop = 0;          /* done loops counter */
+
 
     /* in mode */
     sel_all = 16;		/* Reasonable ballpark figure */
@@ -433,20 +434,22 @@ doIn(Window win, const char *progname)
 	       See ICCCM section 2.2.
 	       Set dloop to sloop for forcing exit after all transfers are completed. */
 	    dloop = sloop;
+        /* if there is no more in-progress transfer, force exit */
+	    if (!requestors) {
+	        return EXIT_SUCCESS;
+	    }
 	    continue;
 	    } else {
 	    continue;
 	    }
 
-	    finished = xcin(dpy, &(requestor->cwin), evt, &(requestor->pty), target, sel_buf, sel_len, &(requestor->sel_pos), &(requestor->context), &(requestor->chunk_size));
+	    finished = xcin(dpy, &(requestor->cwin), evt, &(requestor->pty), target, sel_buf, sel_len, &(requestor->sel_pos), &(requestor->context), &(requestor->chunk_size), &dloop);
 
 	    if (finished) {
 	    del_requestor(requestor);
 	    break;
 	    }
 	}
-
-	dloop++;		/* increment loop counter */
     }
     
     if (fsecm)

--- a/xcprint.c
+++ b/xcprint.c
@@ -53,6 +53,7 @@ prhelp(char *name)
 	    "      -silent      errors only, run in background (default)\n"
 	    "      -quiet       run in foreground, show what's happening\n"
 	    "      -verbose     running commentary\n"
+        "      -secure      zero buffers at exit and imply -loops 1\n"
 	    "\n" "Report bugs to <astrand@lysator.liu.se>\n", name);
     exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
I've added a '-secure' mode that users may wish to use if passing sensitive information in or out of the selection buffers.  The mode also sets the selection loops to 1 so that the selection is cleared after a single paste (in lieu of a timeout feature that many users have requested). The documentation refers to this as implying '-loops 1' and the '-loops' setting will subsequently override this if specified.

The function to zero out the selection buffers is somewhat special because it uses a volatile type function pointer that prevents the compiler from optimizing out the process as a dead-store elimination.  This is the same method that OpenBSD's explicit_bzero and OpenSSL's OPENSSl_cleanse use.  I've also ensured that the parent process wipes its version of sel_buf out before forking if in silent mode.

This is the first pull request for an open-source project I've made, so if I've done something stupid let me know. :)

Edit:
As the '-loops' feature is not working correctly (https://github.com/astrand/xclip/issues/73) I've instead implemented Rik Snel's '-wait' patch from https://github.com/astrand/xclip/issues/8
