### PR TITLE
Fix the issue #64

### DIFF
--- a/xclip.c
+++ b/xclip.c
@@ -415,6 +415,10 @@ doIn(Window win, const char *progname)
 	       See ICCCM section 2.2.
 	       Set dloop to sloop for forcing exit after all transfers are completed. */
 	    dloop = sloop;
+	    /* if there is no more in-progress transfer, force exit */
+	    if (!requestors) {
+	        return EXIT_SUCCESS;
+	    }
 	    continue;
 	    } else {
 	    continue;

--- a/xctest
+++ b/xctest
@@ -36,6 +36,19 @@ do
 	esac
 done
 
+echo "Testing whether xclip exits correctly when the selection is lost"
+echo hello | ./xclip -q -i 2>/dev/null &
+sleep 1
+echo goodbye | ./xclip -i
+sleep 1
+if ps $! > /dev/null; then
+	echo "FAIL: Zombie xclip yet lives! Killing."
+	killall xclip
+    exit 1
+else
+	echo "PASS: xclip exited correctly after losing selection"
+fi
+
 # test xclip on different amounts of data to bring out any errors
 for lines in 2 16 128 1024 8192
 do


### PR DESCRIPTION
Fix the issue #64(https://github.com/astrand/xclip/issues/64).

When receiving a SelectionClear event (i.e; lose the selection), the while loop for checking
dloop as-is ran endlessly if sloop is set to -1 (a.k.a unlimited number of requests).
This caused xclip fail to exist when it loses the selection.

Fix the problem via checking whether there is any in-progress transfer. If no, force xclip exist.