### PR TITLE
Fixed loops incrementation to keep the right count

### DIFF
--- a/xclib.c
+++ b/xclib.c
@@ -321,7 +321,7 @@ xcin(Display * dpy,
      Window * win,
      XEvent evt,
      Atom * pty, Atom target, unsigned char *txt, unsigned long len, unsigned long *pos,
-     unsigned int *context, long *chunk_size)
+     unsigned int *context, long *chunk_size, int *dloop)
 {
     unsigned long chunk_len;	/* length of current chunk (for incr
 				 * transfers only)
@@ -389,6 +389,7 @@ xcin(Display * dpy,
 	    XChangeProperty(dpy,
 			    *win,
 			    *pty, target, 8, PropModeReplace, (unsigned char *) txt, (int) len);
+        *dloop += 1;
 	}
 
 	/* Perhaps FIXME: According to ICCCM section 2.5, we should
@@ -464,6 +465,7 @@ xcin(Display * dpy,
 	     * finished the transfer
 	     */
 	    XChangeProperty(dpy, *win, *pty, target, 8, PropModeReplace, 0, 0);
+        *dloop += 1;
 	}
 	XFlush(dpy);
 

--- a/xclib.h
+++ b/xclib.h
@@ -54,7 +54,8 @@ extern int xcin(
 	unsigned long,
 	unsigned long*,
 	unsigned int*,
-	long*
+	long*,
+    int*
 );
 extern void *xcmalloc(size_t);
 extern void *xcrealloc(void*, size_t);

--- a/xclip.c
+++ b/xclip.c
@@ -420,15 +420,13 @@ doIn(Window win, const char *progname)
 	    continue;
 	    }
 
-	    finished = xcin(dpy, &(requestor->cwin), evt, &(requestor->pty), target, sel_buf, sel_len, &(requestor->sel_pos), &(requestor->context), &(requestor->chunk_size));
+	    finished = xcin(dpy, &(requestor->cwin), evt, &(requestor->pty), target, sel_buf, sel_len, &(requestor->sel_pos), &(requestor->context), &(requestor->chunk_size), &dloop);
 
 	    if (finished) {
 	    del_requestor(requestor);
 	    break;
 	    }
 	}
-
-	dloop++;		/* increment loop counter */
     }
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
I realized after reading this issue https://github.com/astrand/xclip/issues/8 that using '-loops 1' wasn't actually guaranteed to paste a selection into a web browser.  For example, on a terminal window, one paste was fine, but to paste into a Chrome window, it needed to be set to 2 to get one pasting, whereas in the terminal it would still paste 2, so the way the loop was being incremented wasn't right.  Using a Chromium window in MATE actually took 3 loops for one paste.

After playing with the code a little bit, I noticed that even for selections that needed the 32-bit mode of XChangeProperty that uses targets, that there would be a final call to the XChangeProperty that uses the 8-bit mode, so I changed the code to pass a pointer to dloop to xcin() and increment it only after those XChangeProperty calls.  Now if '-loops 1' is specified it will only paste the selection once for the terminal or a browser window regardless of how many XChangeProperty calls it actually calls.