### PR TITLE
Changes -secure mode to -sensitive, making xcmemzero default, documentation changes, bug fix

### DIFF
--- a/xclip.1
+++ b/xclip.1
@@ -69,12 +69,12 @@ provide a running commentary of what xclip is doing
 operate in legacy (i.e. non UTF-8) mode for backwards compatibility
 (Use this option only when really necessary, as the old behavior was broken)
 .TP
-\fB\-secure\fR
-only allow pasting once and overwrite memory with zeros before exiting.
-This implies -wait 1 (-wait will override if set).
+\fB\-sensitive\fR
+clear sensitive data from seleciton buffer immediately upon being pasted.
+This implies -wait 50 (-wait will override if set). See \fBNOTES\fR
 .TP
 \fB\-wait\fR
-number of milliseconds to wait after the first paste event before exiting
+milliseconds after last paste before selection is cleared. This timer will start after the first paste, and reset with each subsequent paste, until allowed to expire and the selection buffer to be cleared.
 
 .PP
 xclip reads text from standard in or files and makes it available to other X applications for pasting as an X selection (traditionally with the middle mouse button). It reads from all files specified, or from standard in if no files are specified. xclip can also print the contents of a selection to standard out with the
@@ -117,6 +117,10 @@ X display to use if none is specified with the
 .B
 \-display
 option.
+
+.SH NOTES
+
+Using the \fB-sensitive\fR option will clear the selection buffer of the sensitive information 50 milliseconds after it has been pasted, effectively only allowing the selection to be pasted once. In some instances this may be too low and will prevent pasting. If this is the case, or if the user needs to be able to past more than once for some other reason, they can adjust the time to wait before clearing the selection with the \fB-wait\fR option.
 
 .SH REPORTING BUGS
 Please report any bugs, problems, queries, experiences, etc. directly to the author.

--- a/xclip.c
+++ b/xclip.c
@@ -599,7 +599,8 @@ doOut(Window win)
 		    XSetSelectionOwner(dpy, sseln, None, CurrentTime);
 			xcmemzero(sel_buf,sel_len);
 		    free(sel_buf);
-		    return EXIT_FAILURE;
+		    errconvsel(dpy, target, sseln);
+		    // errconvsel does not return but exits with EXIT_FAILURE
 		}
 	    }
 

--- a/xclip.c
+++ b/xclip.c
@@ -390,8 +390,8 @@ doIn(Window win, const char *progname)
 	pid = fork();
 	/* exit the parent process; */
 	if (pid) {
-		XSetSelectionOwner(dpy, sseln, None, CurrentTime);
-		xcmemzero(sel_buf,sel_len);
+	    XSetSelectionOwner(dpy, sseln, None, CurrentTime);
+	    xcmemzero(sel_buf,sel_len);
 	    exit(EXIT_SUCCESS);
 	}
     }
@@ -447,7 +447,7 @@ doIn(Window win, const char *progname)
             FD_ZERO(&in_fds);
             FD_SET(x11_fd, &in_fds);
             if (!select(x11_fd + 1, &in_fds, 0, 0, &tv)) {
-				XSetSelectionOwner(dpy, sseln, None, CurrentTime);
+		XSetSelectionOwner(dpy, sseln, None, CurrentTime);
                 xcmemzero(sel_buf,sel_len);
                 return EXIT_SUCCESS;
             }
@@ -486,8 +486,8 @@ start:
     dloop++;		/* increment loop counter */
     }
 
-	XSetSelectionOwner(dpy, sseln, None, CurrentTime);
-	xcmemzero(sel_buf,sel_len);
+    XSetSelectionOwner(dpy, sseln, None, CurrentTime);
+    xcmemzero(sel_buf,sel_len);
 
     return EXIT_SUCCESS;
 }
@@ -594,7 +594,7 @@ doOut(Window win)
 		else {
 		    /* no fallback available, exit with failure */
 		    XSetSelectionOwner(dpy, sseln, None, CurrentTime);
-			xcmemzero(sel_buf,sel_len);
+		    xcmemzero(sel_buf,sel_len);
 		    free(sel_buf);
 		    errconvsel(dpy, target, sseln);
 		    // errconvsel does not return but exits with EXIT_FAILURE
@@ -618,13 +618,13 @@ doOut(Window win)
 	 */
 	printSelBuf(stdout, sel_type, sel_buf, sel_len);
 	if (sseln == XA_STRING) {
-		XSetSelectionOwner(dpy, sseln, None, CurrentTime);
-		xcmemzero(sel_buf,sel_len);
+	    XSetSelectionOwner(dpy, sseln, None, CurrentTime);
+	    xcmemzero(sel_buf,sel_len);
 	    XFree(sel_buf);
 	}
 	else {
-		XSetSelectionOwner(dpy, sseln, None, CurrentTime);
-		xcmemzero(sel_buf,sel_len);
+	    XSetSelectionOwner(dpy, sseln, None, CurrentTime);
+	    xcmemzero(sel_buf,sel_len);
 	    free(sel_buf);
 	}
     }

--- a/xclip.c
+++ b/xclip.c
@@ -200,13 +200,13 @@ doOptMain(int argc, char *argv[])
 	    fprintf(stderr, "Loops: %i\n", sloop);
     }
 
-    /* check for -secure */
-    if (XrmGetResource(opt_db, "xclip.secure", "Xclip.Secure", &rec_typ, &rec_val)
+    /* check for -sensitive */
+    if (XrmGetResource(opt_db, "xclip.sensitive", "Xclip.Sensitive", &rec_typ, &rec_val)
 	) {
-	wait = 1;
+	wait = 50;
 	fsecm = T;
 	if (fverb == OVERBOSE) {	/* print in verbose mode only */
-	    fprintf(stderr, "Secure Mode Implies -wait 1\n");
+	    fprintf(stderr, "Sensitive Mode Implies -wait 1\n");
 	    fprintf(stderr, "Sensitive Buffers Will Be Zeroed At Exit\n");
         }
     }
@@ -215,7 +215,7 @@ doOptMain(int argc, char *argv[])
         ) {
 	wait = atoi(rec_val.addr);
 	if (fverb == OVERBOSE)	/* print in verbose mode only */
-	    fprintf(stderr, "Timeout: %i msec\n", wait);
+	    fprintf(stderr, "wait: %i msec\n", wait);
     }
 
     /* Read remaining options (filenames) */
@@ -370,8 +370,8 @@ doIn(Window win, const char *progname)
     /* Handle cut buffer if needed */
     if (sseln == XA_STRING) {
 	XStoreBuffer(dpy, (char *) sel_buf, (int) sel_len, 0);
-	if (fsecm)		/* -secure-ish (XStoreBuffer made a copy) */
-	    xcmemzero(sel_buf,sel_len);
+	XSetSelectionOwner(dpy, sseln, None, CurrentTime);
+	xcmemzero(sel_buf,sel_len);
 	return EXIT_SUCCESS;
     }
 
@@ -390,9 +390,8 @@ doIn(Window win, const char *progname)
 	pid = fork();
 	/* exit the parent process; */
 	if (pid) {
-	    if (fsecm) {
+		XSetSelectionOwner(dpy, sseln, None, CurrentTime);
 		xcmemzero(sel_buf,sel_len);
-	    }
 	    exit(EXIT_SUCCESS);
 	}
     }
@@ -448,8 +447,8 @@ doIn(Window win, const char *progname)
             FD_ZERO(&in_fds);
             FD_SET(x11_fd, &in_fds);
             if (!select(x11_fd + 1, &in_fds, 0, 0, &tv)) {
-                if(fsecm)
-                    xcmemzero(sel_buf,sel_len);
+				XSetSelectionOwner(dpy, sseln, None, CurrentTime);
+                xcmemzero(sel_buf,sel_len);
                 return EXIT_SUCCESS;
             }
         }
@@ -487,7 +486,7 @@ start:
     dloop++;		/* increment loop counter */
     }
 
-    if (fsecm)
+	XSetSelectionOwner(dpy, sseln, None, CurrentTime);
 	xcmemzero(sel_buf,sel_len);
 
     return EXIT_SUCCESS;
@@ -594,11 +593,13 @@ doOut(Window win)
 		}
 		else {
 		    /* no fallback available, exit with failure */
-		    if (fsecm)
+		    char *atom_name = XGetAtomName(dpy, target);
+		    fprintf(stderr, "Error: target %s not available\n", atom_name);
+		    XFree(atom_name);
+		    XSetSelectionOwner(dpy, sseln, None, CurrentTime);
 			xcmemzero(sel_buf,sel_len);
 		    free(sel_buf);
-		    errconvsel(dpy, target, sseln);
-		    // errconvsel does not return but exits with EXIT_FAILURE
+		    return EXIT_FAILURE;
 		}
 	    }
 
@@ -619,15 +620,13 @@ doOut(Window win)
 	 */
 	printSelBuf(stdout, sel_type, sel_buf, sel_len);
 	if (sseln == XA_STRING) {
-	    if (fsecm) {
+		XSetSelectionOwner(dpy, sseln, None, CurrentTime);
 		xcmemzero(sel_buf,sel_len);
-		}
 	    XFree(sel_buf);
 	}
 	else {
-	    if (fsecm) {
+		XSetSelectionOwner(dpy, sseln, None, CurrentTime);
 		xcmemzero(sel_buf,sel_len);
-	    }
 	    free(sel_buf);
 	}
     }
@@ -734,9 +733,9 @@ main(int argc, char *argv[])
     opt_tab[13].argKind = XrmoptionNoArg;
     opt_tab[13].value = (XPointer) xcstrdup(ST);
 
-    /* secure mode for pasting passwords */
-    opt_tab[14].option = xcstrdup("-secure");
-    opt_tab[14].specifier = xcstrdup(".secure");
+    /* sensitive mode for pasting passwords */
+    opt_tab[14].option = xcstrdup("-sensitive");
+    opt_tab[14].specifier = xcstrdup(".sensitive");
     opt_tab[14].argKind = XrmoptionNoArg;
     opt_tab[14].value = (XPointer) xcstrdup("s");
 

--- a/xclip.c
+++ b/xclip.c
@@ -593,9 +593,6 @@ doOut(Window win)
 		}
 		else {
 		    /* no fallback available, exit with failure */
-		    char *atom_name = XGetAtomName(dpy, target);
-		    fprintf(stderr, "Error: target %s not available\n", atom_name);
-		    XFree(atom_name);
 		    XSetSelectionOwner(dpy, sseln, None, CurrentTime);
 			xcmemzero(sel_buf,sel_len);
 		    free(sel_buf);

--- a/xcprint.c
+++ b/xcprint.c
@@ -164,7 +164,7 @@ fetchname(Display *display, Atom selection, char **namep, Window *wp) {
 
 
 /* failure to convert selection */
-int
+void
 errconvsel(Display *display, Atom target, Atom selection)
 {
     Window w = None;
@@ -172,7 +172,7 @@ errconvsel(Display *display, Atom target, Atom selection)
     char *selection_name = XGetAtomName(display, selection); /* E.g., "PRIMARY" */
 
     if (!selection_name)
-	return 1;		/* Invalid selection Atom  */
+	exit(EXIT_FAILURE);		/* Invalid selection Atom  */
 
     /* Find the name of the window that holds the selection */
     fetchname(display, selection, &window_name, &w);

--- a/xcprint.c
+++ b/xcprint.c
@@ -164,7 +164,7 @@ fetchname(Display *display, Atom selection, char **namep, Window *wp) {
 
 
 /* failure to convert selection */
-void
+int
 errconvsel(Display *display, Atom target, Atom selection)
 {
     Window w = None;

--- a/xcprint.c
+++ b/xcprint.c
@@ -53,7 +53,8 @@ prhelp(char *name)
 	    "      -silent      errors only, run in background (default)\n"
 	    "      -quiet       run in foreground, show what's happening\n"
 	    "      -verbose     running commentary\n"
-	    "      -secure      after first paste, clear memory and exit\n"
+	    "      -sensitive   clear sensitive data from seleciton buffer immediately upon being pasted\n"
+	    "      -wait        wait milliseconds after last paste before selection is cleared\n"
 	    "\n" "Report bugs to <astrand@lysator.liu.se>\n", name);
     exit(EXIT_SUCCESS);
 }
@@ -73,7 +74,7 @@ prversion(void)
 void
 errmalloc(void)
 {
-    fprintf(stderr, "xclip: Error: Could not allocate memory.\n");
+    fprintf(stderr, "Error: Could not allocate memory.\n");
     exit(EXIT_FAILURE);
 }
 
@@ -87,7 +88,7 @@ errxdisplay(char *display)
     if (display == NULL)
 	display = getenv("DISPLAY");
 
-    fprintf(stderr, "xclip: Error: Can't open display: %s\n", display ? display : "(null)");
+    fprintf(stderr, "Error: Can't open display: %s\n", display ? display : "(null)");
     exit(EXIT_FAILURE);
 }
 
@@ -129,81 +130,4 @@ errperror(int prf_tot, ...)
 
     /* free the complete string */
     free(msg_all);
-}
-
-/* a utility for finding the name of the X window that owns the selection. 
- * Sets namep to point to the string of the name (must be freed with XFree). 
- * Sets wp to point to the Window (an integer id).
- * Returns 0 if it works. Not 0, otherwise. 
- */ 
-int
-fetchname(Display *display, Atom selection, char **namep, Window *wp) {
-    *namep = NULL;
-    *wp = XGetSelectionOwner(display, selection);
-    if (*wp == None)
-	return 1;		/* Nobody has the selection. */
-
-    XFetchName(display, *wp, namep);
-    if (*namep)
-	return 0; 		/* Hurrah! It worked on the first try. */
-	
-    /* Otherwise, recursively try the parent windows */
-    Window p = *wp;
-    Window dummy, *dummyp;
-    unsigned int n;
-    while (!*namep  &&  p != None) {
-	if (!XQueryTree(display, p, &dummy, &p, &dummyp, &n))
-	    break;
-	if (p != None) {
-	    XFetchName(display, p, namep);
-	}
-    }
-    return (*namep == NULL);
-}
-
-
-/* failure to convert selection */
-void
-errconvsel(Display *display, Atom target, Atom selection)
-{
-    Window w = None;
-    char *window_name;
-    char *selection_name = XGetAtomName(display, selection); /* E.g., "PRIMARY" */
-
-    if (!selection_name)
-	return 1;		/* Invalid selection Atom  */
-
-    /* Find the name of the window that holds the selection */
-    fetchname(display, selection, &window_name, &w);
-
-    if (w == None) {
-	fprintf(stderr, "xclip: Error: There is no owner for the %s selection\n",
-		selection_name);
-    }
-    else {
-	if (window_name && window_name[0]) {
-	    fprintf(stderr, "xclip: Error: '%s'", window_name);
-	}
-	else {
-	    fprintf(stderr, "xclip: Error: window id 0x%lx", w);
-	}
-	char *atom_name = XGetAtomName(display, target);
-	if (atom_name) {
-	    fprintf(stderr, " cannot convert %s selection to target '%s'\n",
-		    selection_name, atom_name);
-	    XFree(atom_name);
-	}
-	else {
-	    /* Should never happen. */
-	    fprintf(stderr, " cannot convert to NULL target.\n"); 
-	}    
-    }
-
-    if (selection_name)
-	XFree(selection_name);
-
-    if (window_name)
-	XFree(window_name);
-
-    exit(EXIT_FAILURE);
 }

--- a/xcprint.c
+++ b/xcprint.c
@@ -74,7 +74,7 @@ prversion(void)
 void
 errmalloc(void)
 {
-    fprintf(stderr, "Error: Could not allocate memory.\n");
+    fprintf(stderr, "xclip: Error: Could not allocate memory.\n");
     exit(EXIT_FAILURE);
 }
 
@@ -88,7 +88,7 @@ errxdisplay(char *display)
     if (display == NULL)
 	display = getenv("DISPLAY");
 
-    fprintf(stderr, "Error: Can't open display: %s\n", display ? display : "(null)");
+    fprintf(stderr, "xclip: Error: Can't open display: %s\n", display ? display : "(null)");
     exit(EXIT_FAILURE);
 }
 
@@ -130,4 +130,81 @@ errperror(int prf_tot, ...)
 
     /* free the complete string */
     free(msg_all);
+}
+
+/* a utility for finding the name of the X window that owns the selection. 
+ * Sets namep to point to the string of the name (must be freed with XFree). 
+ * Sets wp to point to the Window (an integer id).
+ * Returns 0 if it works. Not 0, otherwise. 
+ */ 
+int
+fetchname(Display *display, Atom selection, char **namep, Window *wp) {
+    *namep = NULL;
+    *wp = XGetSelectionOwner(display, selection);
+    if (*wp == None)
+	return 1;		/* Nobody has the selection. */
+
+    XFetchName(display, *wp, namep);
+    if (*namep)
+	return 0; 		/* Hurrah! It worked on the first try. */
+	
+    /* Otherwise, recursively try the parent windows */
+    Window p = *wp;
+    Window dummy, *dummyp;
+    unsigned int n;
+    while (!*namep  &&  p != None) {
+	if (!XQueryTree(display, p, &dummy, &p, &dummyp, &n))
+	    break;
+	if (p != None) {
+	    XFetchName(display, p, namep);
+	}
+    }
+    return (*namep == NULL);
+}
+
+
+/* failure to convert selection */
+void
+errconvsel(Display *display, Atom target, Atom selection)
+{
+    Window w = None;
+    char *window_name;
+    char *selection_name = XGetAtomName(display, selection); /* E.g., "PRIMARY" */
+
+    if (!selection_name)
+	return 1;		/* Invalid selection Atom  */
+
+    /* Find the name of the window that holds the selection */
+    fetchname(display, selection, &window_name, &w);
+
+    if (w == None) {
+	fprintf(stderr, "xclip: Error: There is no owner for the %s selection\n",
+		selection_name);
+    }
+    else {
+	if (window_name && window_name[0]) {
+	    fprintf(stderr, "xclip: Error: '%s'", window_name);
+	}
+	else {
+	    fprintf(stderr, "xclip: Error: window id 0x%lx", w);
+	}
+	char *atom_name = XGetAtomName(display, target);
+	if (atom_name) {
+	    fprintf(stderr, " cannot convert %s selection to target '%s'\n",
+		    selection_name, atom_name);
+	    XFree(atom_name);
+	}
+	else {
+	    /* Should never happen. */
+	    fprintf(stderr, " cannot convert to NULL target.\n"); 
+	}    
+    }
+
+    if (selection_name)
+	XFree(selection_name);
+
+    if (window_name)
+	XFree(window_name);
+
+    exit(EXIT_FAILURE);
 }

--- a/xcprint.h
+++ b/xcprint.h
@@ -24,4 +24,4 @@ extern void prversion(void);
 extern void errmalloc(void);
 extern void errxdisplay(char *);
 extern void errperror(int, ...);
-extern void errconvsel(Display *display, Atom target, Atom selection);
+extern int errconvsel(Display *display, Atom target, Atom selection);

--- a/xcprint.h
+++ b/xcprint.h
@@ -24,4 +24,4 @@ extern void prversion(void);
 extern void errmalloc(void);
 extern void errxdisplay(char *);
 extern void errperror(int, ...);
-extern int errconvsel(Display *display, Atom target, Atom selection);
+extern void errconvsel(Display *display, Atom target, Atom selection);


### PR DESCRIPTION
This pull implements changes discussed in the comments of https://github.com/astrand/xclip/pull/70

- '-secure' be changed to '-sensitive' and the manual more aptly describe its function
- Call XSetSelectionOwner() to set window owner to None before calling xcmemzero()
- xcmemzero() be used unconditionally to clear selection buffers upon exit
- Default '-wait' period changed from 0 to 50 milliseconds

I had some issues with my fork not being as up to date with astrand/xclip as I thought it was which accidentally reverted some other changes, but I think I have added them all back correctly. I noticed errconvsel() was returning 1 when it needed to be exiting with EXIT_FAILURE so I fixed that.