### PR TITLE
Fix resource leak

### DIFF
--- a/xclip.c
+++ b/xclip.c
@@ -407,6 +407,11 @@ doIn(Window win, const char *progname)
 	    }
 	    sel_len += fread(sel_buf + sel_len, sizeof(char), sel_all - sel_len, fil_handle);
 	}
+
+	if (fil_handle && (fil_handle != stdin)) {
+	    fclose(fil_handle);
+	    fil_handle = NULL;
+	}
     } while (fil_current < fil_number);
 
     /* if there are no files being read from (i.e., input
@@ -416,6 +421,11 @@ doIn(Window win, const char *progname)
     if ((fil_number == 0) && ffilt) {
 	fwrite(sel_buf, sizeof(char), sel_len, stdout);
 	fclose(stdout);
+    }
+
+    if (fil_names) {
+	free(fil_names);
+	fil_names = NULL;
     }
 
     /* remove the last newline character if necessary */


### PR DESCRIPTION
1). File handles from fopen should be closed by fclose after use.
    Free fil_handle in the function doIn after reading date from each file.

2). Memory allocated from xcmalloc/xcrealloc should be freed after use.
    Free file_names in the function doIn after reading data from all files.