### PR TITLE
Add support for GNU-style command line options

### DIFF
--- a/xclip.c
+++ b/xclip.c
@@ -176,6 +176,14 @@ int clean_requestors() {
 static void
 doOptMain(int argc, char *argv[])
 {
+    /* Support both -option and --option form. */
+    int i;
+    for (i = 1; i < argc; ++i) {
+	if (!strncmp(argv[i], "--", 2)) {
+	    argv[i]++;
+	}
+    }
+
     /* Initialise resource manager and parse options into database */
     XrmInitialize();
     XrmParseCommand(&opt_db, opt_tab, opt_tab_size, PACKAGE_NAME, &argc,


### PR DESCRIPTION
`xclip` supports only `-option` style option, but it's common for Unix command line tools to have 
GNU style command line options (i.e. `--option` style.)

This PR adds support for GNU style command line option, keeping compatibility to Xrm\* functions by removing
first hyphen if GNU style command line options are passed.