### PR TITLE
Allow out of source build

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -5,6 +5,8 @@ bindir      = @bindir@
 mandir      = @mandir@
 datarootdir = @datarootdir@
 datadir     = @datadir@
+srcdir      = @srcdir@
+VPATH       = @srcdir@
 
 VERSION     = @PACKAGE_VERSION@
 
@@ -73,8 +75,8 @@ xclip-$(VERSION).tar.gz:
 Makefile: Makefile.in configure
 	./config.status
 
-configure: configure.ac
-	./bootstrap
+$(srcdir)/configure: configure.ac
+	$(srcdir)/bootstrap $(srcdir)
 
 borked: borked.c xclib.o xcprint.o 
 	$(CC) $^ $(CFLAGS) -o $@ $(X11OBJ) $(LDFLAGS)

--- a/bootstrap
+++ b/bootstrap
@@ -1,3 +1,3 @@
 #!/bin/sh
 rm -rf autom4te.cache
-autoreconf -i
+autoreconf -i "$@"


### PR DESCRIPTION
It is convenient to keep build artifacts aside from sources.
Just specify path to configure script while current working directory
is the build directory:

    /path/to/xclip/configure