### PR TITLE
Allow to specify stdin as "-"

### DIFF
--- a/xclip.c
+++ b/xclip.c
@@ -372,7 +372,7 @@ doIn(Window win, const char *progname)
 
     /* Put chars into inc from stdin or files until we hit EOF */
     do {
-	if (fil_number == 0) {
+	if (fil_number == 0 || strcmp(fil_names[fil_current], "-") == 0) {
 	    /* read from stdin if no files specified */
 	    fil_handle = stdin;
 	}

--- a/xctest
+++ b/xctest
@@ -99,6 +99,23 @@ do
     done
     echo
 
+    # test piping the file to xclip
+    echo Piping a $lines line file to xclip using -
+    for sel in primary secondary clipboard buffer
+    do
+	echo -n "  Using the $sel selection	"
+	cat $tempi | $checker ./xclip -sel $sel -i -
+	sleep $delay
+	$checker ./xclip -sel $sel -o > $tempo
+	if diff $tempi $tempo; then
+	    echo "PASS"
+	else
+	    echo "FAIL"
+	    exit 1
+	fi
+    done
+    echo
+
     # test xclip reading the file
     echo Reading a $lines line file with xclip
     for sel in primary secondary clipboard buffer


### PR DESCRIPTION
It is wide spread convention to use dash as stdin where file name
argument is expected. E.g. it is convenient to have common user
configurable command where either real file or `-` could be substituted:

    xclip -in -target %t %f