### PR TITLE
fix segfault on conversion error

### DIFF
--- a/xclip.c
+++ b/xclip.c
@@ -278,7 +278,7 @@ doOptMain(int argc, char *argv[])
 	fil_number++;
     }
 
-    /* If filenames were given on the command line, 
+    /* If filenames were given on the command line,
      * default to reading input (unless -o was used).
      */
     if (fil_number > 0) {
@@ -745,7 +745,6 @@ doOut(Window win)
 			/* Clear memory buffer */
 			xcmemzero(sel_buf,sel_len);
 		    }
-		    free(sel_buf);
 		    errconvsel(dpy, target, sseln);
 		    // errconvsel does not return but exits with EXIT_FAILURE
 		}
@@ -937,7 +936,7 @@ main(int argc, char *argv[])
 		sizeof(opt_tab) / sizeof(opt_tab[0]), opt_tab_size);
 	return EXIT_FAILURE;
     }
-		
+
 
     /* parse command line options */
     doOptMain(argc, argv);


### PR DESCRIPTION
When I copy some text from a github commit inside Chrome,
the selection cannot be converted to text.
When I run `xclip -o` with that selection in the paste buffer,
I get a segmentation fault because `free` is being called with
an invalid argument (presumably because xcout isn't setting the
`sel_buf` pointer correctly on error).

```
% xclip -o
1587474: signal: sys: segmentation violation (core dumped)
```

To fix this, remove the call to `free` in the error case, as it isn't really necessary
anyway as the program is about to exit.

When the `free` call is removed, `xclip` prints this error instead of seg-faulting:

```
xclip: Error: 'Chromium clipboard' (0x1c00024) cannot convert PRIMARY selection to target 'STRING'
```