### PR TITLE
make (some) file-scope identifiers static

### DIFF
--- a/xclip.c
+++ b/xclip.c
@@ -56,10 +56,10 @@ static int fsecm = F;		/* zero out selection buffer before exiting */
 Display *dpy;			/* connection to X11 display */
 XrmDatabase opt_db = NULL;	/* database for options */
 
-char **fil_names;		/* names of files to read */
-int fil_number = 0;		/* number of files to read */
-int fil_current = 0;
-FILE *fil_handle = NULL;
+static char **fil_names;		/* names of files to read */
+static int fil_number = 0;		/* number of files to read */
+static int fil_current = 0;
+static FILE *fil_handle = NULL;
 
 /* variables to hold Xrm database record and type */
 XrmValue rec_val;


### PR DESCRIPTION
According to `grep -ER 'fil_names|fil_number|fil_current|fil_handle' .`  none of those are in use in other source files. 

In theory all of the file-scope variables in this file should be static in the typical C style since there's no corresponding header, but I see that at least "dpy" is used elsewhere, so I didn't bother with that one and others before asking: are patches for code correctness and small style fixes accepted?