### PR TITLE
correct printf conversion specifier for sel_all

### DIFF
--- a/xclip.c
+++ b/xclip.c
@@ -402,7 +402,7 @@ doIn(Window win, const char *progname)
 		sel_all *= 2;
 		sel_buf = (unsigned char *) xcrealloc(sel_buf, sel_all * sizeof(char) );
 		if (xcverb >= ODEBUG) {
-		    fprintf(stderr, "xclip: debug: Increased buffersize to %ld\n", sel_all);
+		    fprintf(stderr, "xclip: debug: Increased buffersize to %lu\n", sel_all);
 		}
 	    }
 	    sel_len += fread(sel_buf + sel_len, sizeof(char), sel_all - sel_len, fil_handle);


### PR DESCRIPTION
sel_all is an unsigned long, but the printf conversion specifier is for a signed long.