### PR TITLE
add the Meson build system

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,40 @@
+project('xclip', 'c',
+  version : '0.13',
+  default_options : ['warning_level=3', 'c_std=c99', 'b_lto=true'])
+
+add_project_arguments(['-DPACKAGE_NAME="xclip"',
+                      '-DPACKAGE_VERSION=' + '"' + meson.project_version() + '"'],
+                      language : 'c')
+
+
+dep = [dependency('x11'), dependency('xmu')]
+inc = [include_directories('.')]
+cc = meson.get_compiler('c')
+iconv_inc = include_directories(get_option('prefix') / get_option('includedir'))
+iconv_dep = cc.find_library('iconv',
+                            dirs : get_option('prefix') / get_option('libdir'),
+                            has_headers : 'iconv.h',
+                            header_include_directories : iconv_inc,
+                            required : false)
+if iconv_dep.found() == true
+  dep += iconv_dep
+  inc += iconv_inc
+  add_project_arguments('-DHAVE_ICONV', language : 'c')
+endif
+
+executable('xclip',
+           ['xclib.c', 'xclip.c', 'xcprint.c'],
+           include_directories : inc,
+           dependencies : dep,
+           install : true)
+
+borked_test = executable('borked',
+                         ['borked.c', 'xclib.c', 'xcprint.c'],
+                         include_directories : inc,
+                         dependencies : dep)
+test('borked', borked_test)
+
+install_data(['xclip-copyfile', 'xclip-cutfile', 'xclip-pastefile'],
+             install_dir : get_option('prefix') / get_option('bindir'))
+install_man(['xclip-copyfile.1', 'xclip.1'])
+


### PR DESCRIPTION
Hello, I've written Meson build definitions for xclip. 

This patch appears to depend on #123 on my system, without it a build error occurs due to the missing #include. That's not a build system issue so it's in its own PR.

I've kept the new build system mostly functionally the same as the autotools-based one, I'm not aware of any lost functionality. The differences are as follows:
- The build is now done with Link Time Optimization by default.
- Meson abstracts enabling compiler warnings, I've set them to the highest level which for GCC and Clang translates into "-Wall -Wextra -Wpedantic". This differs from the Autotools script which uses "-Wall" under GCC.
- I've explicitly set the C standard to C99, the project didn't build with Clang/GCC set to C89 mode due to mixing declarations and code.
- The test in "borked.c" was integrated into Meson's test support, "xctest" wasn't because I haven't figured out how to do it.


I think Meson is a better build system because it took me roughly 9 hours to translate the Autotools definitions into a meson.build and test the result, and this has already gained the project the following:
- Out of source build support, requested in #111. Meson always uses a build directory, this directory can be outside the source.
- Meson produces a [compile_commands.json](https://clang.llvm.org/docs/JSONCompilationDatabase.html) file. 
- pkg-config is used to find Xmu, iconv on the other hand is a complicated case and may be part of the libc or provided by something like GNU libiconv, I've only tested this patch on OpenBSD and it appears to find libiconv where Autotools can't.
- Simplified build. Just type ```meson setup build``` and ```meson compile -C build``` and Meson sets itself up in the "build" directory and produces a debug binary at "build/xclip".
- Test integration. This should make it easy for package maintainers to test xclip before updating it in their distro/OS, it should also make it easier for xclip developers to produce and run tests. So far only "borked.c" is integrated.
- Ease of development. Meson notices when you change your compiler flags and triggers a rebuild, Meson also notices changes made to headers included by source files and triggers rebuilds of files that include the specific header.
- Whichever Meson feature turns out to be useful. Meson supports cross compilation, many compilers, test coverage reports, it automagically figures out what to put in a dist file, it runs on Windows, it makes separating the source tree into folders easy and more.

All of this by depending on Python, Ninja and Meson at build time.