### PR TITLE
xclip.1: rewrite in the mdoc(7) format

### DIFF
--- a/xclip.1
+++ b/xclip.1
@@ -1,8 +1,5 @@
-.\"
-.\"
-.\" xclip.man - xclip manpage
-.\" Copyright (C) 2001 Kim Saunders
-.\" Copyright (C) 2007-2008 Peter Åstrand
+.\" xclip.1 - xclip manpage
+.\" Copyright (C) 2021 Guilherme Janczak
 .\"
 .\" This program is free software; you can redistribute it and/or modify
 .\" it under the terms of the GNU General Public License as published by
@@ -17,134 +14,168 @@
 .\" along with this program; if not, write to the Free Software
 .\" Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 .\"
-.TH XCLIP 1
-.SH NAME
-xclip \- command line interface to X selections (clipboard)
-.SH SYNOPSIS
-.B xclip
-[OPTION] [FILE]...
-.SH DESCRIPTION
-Reads from standard in, or from one or more files, and makes the data available as an X selection for pasting into X applications. Prints current X selection to standard out.
-.TP
-\fB\-i\fR, \fB\-in\fR
-read text into X selection from standard input or files (default)
-.TP
-\fB\-o\fR, \fB\-out\fR
-print the selection to standard out (generally for piping to a file or program)
-.TP
-\fB\-f\fR, \fB\-filter\fR
-when xclip is invoked in the in mode with output level set to silent (the defaults), the filter option will cause xclip to print the text piped to standard in back to standard out unmodified
-.TP
-\fB\-r\fR, \fB\-rmlastnl\fR
-when the last character of the selection is a newline character, remove it. Newline characters that are not the last character in the selection are not affected. If the selection does not end with a newline character, this option has no effect. This option is useful for copying one-line output of programs like \fBpwd\fR to the clipboard to paste it again into the command prompt without executing the line immediately due to the newline character \fBpwd\fR appends.
-.TP
-\fB\-l\fR \fIn\fR, \fB\-loops\fR \fIn\fR
-number of X selection requests (pastes into X applications) to wait for before exiting, with a value of 0 (default) causing xclip to wait for an unlimited number of requests until another application (possibly another invocation of xclip) takes ownership of the selection.
-.TP
-\fB\-t\fR \fIt\fR, \fB\-target\fR \fIt\fR
-specify a particular data format using the given target atom. With \fB\-o\fR the
-special target atom name "TARGETS" can be used to get a list of valid target
-atoms for this selection. The default target is "STRING". For more information
-about target atoms refer to ICCCM section 2.6.2
-.TP
-\fB\-alt-text\fR \fIt\fR
-specify an alternative text to put into the target atom "STRING". Some applications refuse to paste text unless this atom is provided in addition to other text targets such as "text/html".
-.TP
-\fB\-d\fR, \fB\-display\fR
-X display to use (e.g. "localhost:0"), xclip defaults to the value in $\fBDISPLAY\fR if this option is omitted
-.TP
-\fB\-h\fR, \fB\-help\fR
-show quick summary of options
-.TP
-\fB\-selection\fR
-specify which X selection to use, options are "primary" to use XA_PRIMARY (default), "secondary" for XA_SECONDARY or "clipboard" for XA_CLIPBOARD
-.TP
-\fB\-version\fR
-show version information
-.TP
-\fB\-silent\fR
-fork into the background to wait for requests, no informational output, errors only (default)
-.TP
-\fB\-quiet\fR
-show informational messages on the terminal and run in the foreground
-.TP
-\fB\-verbose\fR
-provide a running commentary of what xclip is doing
-.TP
-\fB\-noutf8\fR
-operate in legacy (i.e. non UTF-8) mode for backwards compatibility
-(Use this option only when really necessary, as the old behavior was broken)
-.TP
-\fB\-sensitive\fR
-clear sensitive data from selection buffer after being pasted once.
-This is currently implemented as -wait 50. See \fBNOTES\fR
-.TP
-\fB\-wait\fR \fIn\fR
-after the first paste, wait for \fIn\fR milliseconds. If a subsequent paste
-request arrives before the timer expires, reset the timer. Once the timer
-expires, the selection buffer is cleared so the data cannot be pasted again.
-
-.PP
-xclip reads text from standard in or files and makes it available to other X applications for pasting as an X selection (traditionally with the middle mouse button). It reads from all files specified, or from standard in if no files are specified. xclip can also print the contents of a selection to standard out with the
-.B
-\-o
-option.
-
-xclip was designed to allow tighter integration of X applications and command line programs. The default action is to silently wait in the background for X selection requests (pastes) until another X application places data in the clipboard, at which point xclip exits silently. You can use the \fB\-verbose\fR option to see if and when xclip actually receives selection requests from other X applications.
-
-Options can be abbreviated as long as they remain unambiguous. For example, it is possible to use \fB\-d\fR or \fB\-disp\fR instead of \fB\-display\fR. However, \fB\-v\fR couldn't be used because it is ambiguous (it could be short for \fB\-verbose\fR or \fB\-version\fR), so it would be interpreted as a filename.
-
-Note that only the first character of the selection specified with the \fB\-selection\fR option is important. This means that "p", "sec" and "clip" would have the same effect as using "primary", "secondary" or "clipboard" respectively.
-
-.SH EXAMPLES
-.PP
-I hate man pages without examples!
-
-.B
-uptime | xclip
-.PP
-Put your uptime in the X selection. Then middle click in an X application to paste.
-
-.B xclip -o > helloworld.c
-.PP
-Put the contents of the selection into a file.
-
-.B xclip -t text/html index.html
-.PP
-Middle click in an X application supporting HTML to paste the contents of the given file as HTML.
-
-.B xclip -loops 10 -verbose /etc/motd
-.PP
-Exit after /etc/motd (message of the day) has been pasted 10 times. Show how many selection requests (pastes) have been processed.
-
-.SH NOTES
-
-Using the \fB\-sensitive\fR option will clear the selection buffer of the
-sensitive information 50 milliseconds after it has been pasted, effectively only
-allowing the selection to be pasted once. In some instances this may be too low
-and will prevent pasting. If this is the case, or if the user needs to be able
-to paste more than once for some other reason, they may use \fB\-wait\fR \fIn\fR
-instead. \fB\-wait\fR is the same as \fB\-sensitive\fR, except it allows one to
-adjust the time to wait before clearing the selection to be \fIn\fR
-milliseconds.
-.PP
-Ideally, \fB\-sensitive\fR would allow exactly one paste and not need a timeout,
-but due to subtleties in the way the X clipboard protocol works, doing so is not
-as simple as it may seem.
-
-.SH ENVIRONMENT
-.TP
-.SM
-\fBDISPLAY\fR
-X display to use if none is specified with the
-.B
-\-display
-option.
-
-.SH REPORTING BUGS
-Please report any bugs, problems, queries, experiences, etc. directly to the author.
-
-.SH AUTHORS
-Kim Saunders <kims@debian.org>
-Peter Åstrand <astrand@lysator.liu.se>
-.br
+.Dd December 27, 2024
+.Dt XCLIP 1
+.Os
+.Sh NAME
+.Nm xclip
+.Nd command line interface to X selections (clipboard)
+.Sh SYNOPSIS
+.Nm
+.Op Fl fhior
+.Op Fl d Ar display
+.Op Fl l Ar loops
+.Op Fl t Ar atom
+.Op Fl alt-text Ar text
+.Op Fl noutf8
+.Op Fl version
+.Op Fl silent | quiet | verbose
+.Op Fl selection Cm primary | secondary | clipboard
+.Op Fl sensitive | Fl wait Ar milliseconds
+.Op Ar
+.Sh DESCRIPTION
+The
+.Nm
+utility reads from stdin, or from one or more files,
+and makes the data available as an X selection for pasting into X applications.
+It reads from all files specified in the order of the arguments,
+or from stdin if no files are specified.
+If a
+.Ar file
+is a single dash
+.Po Qo Sy - Qc Pc ,
+then it is read from stdin.
+.Pp
+The default action is to silently wait in the background,
+listening for X selection requests (pastes),
+until another X application places data in the clipboard.
+.Pp
+Options can be abbreviated as long as they remain unambiguous.
+For example, it's possible to use
+.Fl d
+or
+.Fl disp
+instead of
+.Fl display .
+However,
+.Fl v
+can't be used because it could be either of
+.Fl verbose
+or
+.Fl version ,
+in which case
+.Fl v
+would be interpreted as a filename.
+.Pp
+The options are as follows:
+.Bl -tag -width Ds
+.It Fl alt-text Ar text
+Specify an alternative
+.Ar text
+to put into the target atom "STRING".
+Some applications refuse to paste text unless this atom is provided in addition
+to other text targets such as "text/html".
+.It Fl d Ar display , Fl display Ar display
+X display to use (e.g. "localhost:0"),
+.Nm
+defaults to the value in $DISPLAY if this option is omitted.
+.It Fl f , filter
+When
+.Nm
+is invoked with the
+.Fl i
+and
+.Fl silent
+options (the defaults), the
+.Fl f
+option will cause
+.Nm
+to copy stdin to stdout unmodified.
+.It Fl h , help
+Show a quick summary of the options.
+.It Fl i , in
+Read text into the X selection from standard input or files (default).
+.It Fl l Ar loops , Fl loops Ar loops
+Number of X selection requests (pastes into X applications) to wait for.
+A value of 0 (default) causes
+.Nm
+to wait for an unlimited number of requests,
+or until another X application takes ownership of the selection.
+.It Fl noutf8
+Operate in legacy (i.e. non UTF-8) mode.
+This option exists for backwards compatibility only,
+it should not be used otherwise.
+.It Fl o , out
+Print the selection to stdout.
+.It Fl quiet
+Show informational messages on the terminal and run in the foreground.
+.It Fl r , rmlastnl
+If the last character of the selection is a newline, remove it.
+.It Fl selection Cm primary | secondary | clipboard
+Specify the X selection to use.
+Only the first character of the argument is significant,
+thus
+.Cm p
+is equivalent to
+.Cm primary ,
+.Cm sec
+is equivalent to
+.Cm secondary ,
+and
+.Cm cl
+is equivalent to
+.Cm clipboard .
+.It Fl sensitive
+Clear the selection buffer after pasting once.
+.It Fl silent
+Fork into the background to wait for requests, only output errors (default).
+.It Fl t Ar atom , Fl target Ar atom
+Specify a particular format using the given target
+.Ar atom .
+With
+.Fl o ,
+the special
+.Ar atom
+name "TARGETS" will produce a list of valid
+.Ar atom Ns s
+for this selection.
+The default target is "STRING".
+For more information about target atoms refer to ICCCM section 2.6.2.
+.It Fl verbose
+Provide a running commentary of what
+.Nm
+is doing.
+.It Fl version
+Show version information.
+.It Fl wait Ar milliseconds
+After the first paste, a timer counts down from the specified time.
+If a subsequent paste arrives before the timer expires, reset the timer.
+Once the timer expires, the selection is cleared.
+.El
+.Sh EXIT STATUS
+.Ex -std
+.Sh EXAMPLES
+Place the uptime into the X selection:
+.Dl $ uptime | xclip
+.Pp
+Put the contents of the selection into a file:
+.Dl $ xclip -o > helloworld.c
+.Pp
+Exit after /etc/motd has been pasted 10 times,
+and show how many selection requests (pastes) have been processed:
+.Dl $ xclip -l 10 -verbose /etc/motd
+.Pp
+Take a screenshot and copy it to the clipboard:
+.Dl $ scrot -e 'xclip -selection clipboard -t image/png -i $f'
+.Sh AUTHORS
+.An Kim Saunders Aq Mt kims@debian.org
+.An Peter Åstrand Aq Mt astrand@lysator.liu.se
+.An Guilherme Janczak Ao Mt guilherme.janczak@yandex.com Ac Po this manual Pc
+.Sh BUGS
+.Fl sensitive
+is currently implemented as
+.Fl wait
+50.
+.Pp
+Open an issue or a pull request at
+.Lk https://github.com/astrand/xclip


### PR DESCRIPTION
As suggested in #96. The new manual isn't an exact copy, most of it is rewritten.
My name is in the copyright because I started from scratch and wrote most of the text (though it is based off the old manual), I'm not sure how this copyright stuff is supposed to work.
I've also credited myself among the authors, stating clearly that my authorship is limited to this manual, if that is not considered too scandalous.

This manual also includes the example found in #114.