### PR TITLE
Add -alt-text option to set STRING (for text/html to work in Chrome)

### DIFF
--- a/xclib.h
+++ b/xclib.h
@@ -66,6 +66,7 @@ extern int xcin(
 	unsigned char*,
 	unsigned long,
 	unsigned long*,
+	char*,
 	unsigned int*,
 	long*
 );

--- a/xclip.1
+++ b/xclip.1
@@ -47,6 +47,9 @@ special target atom name "TARGETS" can be used to get a list of valid target
 atoms for this selection. The default target is "STRING". For more information
 about target atoms refer to ICCCM section 2.6.2
 .TP
+\fB\-alt-text\fR \fIt\fR
+specify an alternative text to put into the target atom "STRING". Some applications refuse to paste text unless this atom is provided in addition to other text targets such as "text/html".
+.TP
 \fB\-d\fR, \fB\-display\fR
 X display to use (e.g. "localhost:0"), xclip defaults to the value in $\fBDISPLAY\fR if this option is omitted
 .TP

--- a/xclip.c
+++ b/xclip.c
@@ -35,7 +35,7 @@
 #include "xclib.h"
 
 /* command line option table for XrmParseCommand() */
-XrmOptionDescRec opt_tab[17];
+XrmOptionDescRec opt_tab[18];
 int opt_tab_size;
 
 /* Options that get set on the command line */
@@ -43,6 +43,7 @@ int sloop = 0;			/* number of loops */
 char *sdisp = NULL;		/* X display to connect to */
 Atom sseln = XA_PRIMARY;	/* X selection to work with */
 Atom target = XA_STRING;
+char *alt_text = NULL;		/* Text to put into textual targets */
 int wait = 0;              /* wait: stop xclip after wait msec
                             after last 'paste event', start counting
                             after first 'paste event' */
@@ -263,6 +264,14 @@ doOptMain(int argc, char *argv[])
 	wait = atoi(rec_val.addr);
 	if (xcverb >= OVERBOSE)
 	    fprintf(stderr, "wait: %i msec\n", wait);
+    }
+
+    /* check for -alt-text */
+    if (XrmGetResource(opt_db, "xclip.alt-text", "Xclip.Alt-text", &rec_typ, &rec_val)
+	) {
+	alt_text = rec_val.addr;
+	if (xcverb >= OVERBOSE)	/* print in verbose or debug mode only */
+	    fprintf(stderr, "Alternative text: %s\n", alt_text);
     }
 
     /* Read remaining options (filenames) */
@@ -617,7 +626,8 @@ start:
 
 	    finished = xcin(dpy, &(requestor->cwin), evt, &(requestor->pty),
 			    target, sel_buf, sel_len, &(requestor->sel_pos),
-			    &(requestor->context), &(requestor->chunk_size));
+			    alt_text, &(requestor->context),
+			    &(requestor->chunk_size));
 
 	    if (finished) {
 		del_requestor(requestor);
@@ -904,6 +914,13 @@ main(int argc, char *argv[])
     /* target option entry */
     opt_tab[i].option = xcstrdup("-target");
     opt_tab[i].specifier = xcstrdup(".target");
+    opt_tab[i].argKind = XrmoptionSepArg;
+    opt_tab[i].value = (XPointer) NULL;
+    i++;
+
+    /* alt-text option entry */
+    opt_tab[i].option = xcstrdup("-alt-text");
+    opt_tab[i].specifier = xcstrdup(".alt-text");
     opt_tab[i].argKind = XrmoptionSepArg;
     opt_tab[i].value = (XPointer) NULL;
     i++;

--- a/xcprint.c
+++ b/xcprint.c
@@ -40,6 +40,7 @@ prhelp(char *name)
 "  -o, -out         prints the selection to standard out\n"
 "      -selection   primary [DEFAULT], clipboard, secondary, or buffer-cut\n"
 "      -target      specify target atom: image/jpeg, UTF8_STRING [DEFAULT]\n"
+"      -alt-text    specify text representation for STRING target\n"
 "      -silent      errors only, (run in background) [DEFAULT]\n"
 "      -quiet       minimal output (foreground)\n"
 "      -verbose     running commentary (foreground)\n"


### PR DESCRIPTION
I would like to propose a new option, `-alt-text t`, that sets a `STRING` target in addition to whatever target atom is set from stdin/a file. So the command line

```
echo -n Bar | xclip -i -sel clip -alt-text Foo -t text/html
```

will result in `Foo` being pasted into terminals, and `Bar` being posted in web browsers.

The reason I'd like to have such an option is that Chrome does not offer the option to paste HTML into text fields unless the `STRING` atom target is set and non-empty. To be precise, without `-alt-text`, I cannot paste HTML into a chat in the Slack website running in Chromium.