### PR TITLE
Fix minor strict-aliasing violation and add option -appendnl

### DIFF
--- a/xclip.1
+++ b/xclip.1
@@ -35,6 +35,9 @@ print the selection to standard out (generally for piping to a file or program)
 \fB\-f\fR, \fB\-filter\fR
 when xclip is invoked in the in mode with output level set to silent (the defaults), the filter option will cause xclip to print the text piped to standard in back to standard out unmodified
 .TP
+\fB\-a\fR, \fB\-appendnl\fR
+when the last character of the selection is not a newline character, append one anyway. If the selection does end with a newline character, this option has no effect. When this option is set alongside \fB\-rmlastnl\fR, then neither has any effect.
+.TP
 \fB\-r\fR, \fB\-rmlastnl\fR
 when the last character of the selection is a newline character, remove it. Newline characters that are not the last character in the selection are not affected. If the selection does not end with a newline character, this option has no effect. This option is useful for copying one-line output of programs like \fBpwd\fR to the clipboard to paste it again into the command prompt without executing the line immediately due to the newline character \fBpwd\fR appends.
 .TP

--- a/xclip.c
+++ b/xclip.c
@@ -719,8 +719,11 @@ doOut(Window win)
     XEvent evt;			/* X Event Structures */
     unsigned int context = XCLIB_XCOUT_NONE;
 
-    if (sseln == XA_STRING)
-	sel_buf = (unsigned char *) XFetchBuffer(dpy, (int *) &sel_len, 0);
+    if (sseln == XA_STRING) {
+	int sel_ilen = 0;
+	sel_buf = (unsigned char *) XFetchBuffer(dpy, &sel_ilen, 0);
+	sel_len = (unsigned long)sel_ilen;
+    }
     else {
 	while (1) {
 	    /* only get an event if xcout() is doing something */

--- a/xcprint.c
+++ b/xcprint.c
@@ -48,6 +48,7 @@ prhelp(char *name)
 "  -l, -loops       number of selection requests to wait for before exiting\n"
 "      -wait n      exit n milliseconds pasting, timer restarts on each paste\n"
 "      -noutf8      don't treat text as utf-8, use old unicode\n"
+"      -appendnl    append a newline character if not present\n"
 "      -rmlastnl    remove the last newline character if present\n"
 "  -d, -display     X display to connect to (eg localhost:0\")\n"
 "      -version     version information\n"


### PR DESCRIPTION
`-appendnl` appends a newline at the end of the selection if not present.